### PR TITLE
Add links to the comic strip images in README files

### DIFF
--- a/Elvie_033/README.md
+++ b/Elvie_033/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #033](Elvie_033_en-GB.jpg)
+
 Elvie #033
 ==========
 This strip appeared in issue #193 of Linux (Pro) Magazine. Whilst creating this strip we were unaware that

--- a/Elvie_034/README.md
+++ b/Elvie_034/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #034](Elvie_034_en-GB.jpg)
+
 Elvie #034
 ==========
 This strip appeared in issue #194 of Linux (Pro) Magazine.

--- a/Elvie_035/README.md
+++ b/Elvie_035/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #035](Elvie_035_en-GB.jpg)
+
 Elvie #035
 ==========
 This strip appeared in issue #195 of Linux (Pro) Magazine. This was the first strip we created after finding out

--- a/Elvie_036/README.md
+++ b/Elvie_036/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #036](Elvie_036_en-GB.jpg)
+
 Elvie #036
 ==========
 This strip appeared in issue #196 of Linux (Pro) Magazine.

--- a/Elvie_037/README.md
+++ b/Elvie_037/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #037](Elvie_037_en-GB.jpg)
+
 Elvie #037
 ==========
 This strip appeared in issue #197 of Linux (Pro) Magazine, after it was confirmed that the Democrats' email

--- a/Elvie_038/README.md
+++ b/Elvie_038/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #038](Elvie_038_en-GB.jpg)
+
 Elvie #038
 ==========
 This strip was created in January/February of 2017 and appeared in issue #198 of Linux (Pro) Magazine. It's one of

--- a/Elvie_039/README.md
+++ b/Elvie_039/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #039](Elvie_039_en-GB.jpg)
+
 Elvie #039
 ==========
 This strip was created in February/March of 2017 and appeared in issue #199 of Linux (Pro) Magazine. It's the second

--- a/Elvie_040/README.md
+++ b/Elvie_040/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #040](Elvie_040_en-GB.jpg)
+
 Elvie #040
 ==========
 This strip appeared in issue #200 of Linux (Pro) Magazine.

--- a/Elvie_041/README.md
+++ b/Elvie_041/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #041](Elvie_041_en-GB.jpg)
+
 Elvie #041
 ==========
 This strip appeared in issue #201 of Linux (Pro) Magazine, shortly after Canonical announced that they were

--- a/Elvie_042/README.md
+++ b/Elvie_042/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #042](Elvie_042_en-GB.jpg)
+
 Elvie #042
 ==========
 This strip appeared in issue #202 of Linux (Pro) Magazine, shortly after the WannaCry malware hit the UK's

--- a/Elvie_043/README.md
+++ b/Elvie_043/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #043](Elvie_043_en-GB.jpg)
+
 Elvie #043
 ==========
 This strip appeared in issue #203 of Linux (Pro) Magazine.

--- a/Elvie_044/README.md
+++ b/Elvie_044/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #044](Elvie_044_en-GB.jpg)
+
 Elvie #044
 ==========
 This strip appeared in issue #204 of Linux (Pro) Magazine. It's the second of a pair of strips, so if you haven't seen it yet you might want to look at [the previous one](http://peppertop.com/elvie/comic/elvie-043/) as well.

--- a/Elvie_045/README.md
+++ b/Elvie_045/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #045](Elvie_045_en-GB.jpg)
+
 Elvie #045
 ==========
 This strip appeared in issue #205 of Linux (Pro) Magazine.

--- a/Elvie_046/README.md
+++ b/Elvie_046/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #046](Elvie_046_en-GB.jpg)
+
 Elvie #046
 ==========
 

--- a/Elvie_047/README.md
+++ b/Elvie_047/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #047](Elvie_047_en-GB.jpg)
+
 Elvie #047
 ==========
 This strip appeared in issue #207 of Linux (Pro) Magazine.

--- a/Elvie_048/README.md
+++ b/Elvie_048/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #048](Elvie_048_en-GB.jpg)
+
 Elvie #048
 ==========
 This strip appeared in issue #208 of Linux (Pro) Magazine.

--- a/Elvie_049/README.md
+++ b/Elvie_049/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #049](Elvie_049_en-GB.jpg)
+
 Elvie #049
 ==========
 This strip appeared in issue #209 of Linux (Pro) Magazine.

--- a/Elvie_050/README.md
+++ b/Elvie_050/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #050](Elvie_050_en-GB.jpg)
+
 Elvie #050
 ==========
 This strip appeared in issue #210 of Linux (Pro) Magazine.

--- a/Elvie_051/README.md
+++ b/Elvie_051/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #051](Elvie_051_en-GB.jpg)
+
 Elvie #051
 ==========
 This strip appeared in issue #211 of Linux (Pro) Magazine.

--- a/Elvie_052/README.md
+++ b/Elvie_052/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #052](Elvie_052_en-GB.jpg)
+
 Elvie #052
 ==========
 This strip appeared in issue #212 of Linux (Pro) Magazine in early 2018, at a time when there was much

--- a/Elvie_053/README.md
+++ b/Elvie_053/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #053](Elvie_053_en-GB.jpg)
+
 Elvie #053
 ==========
 This strip appeared in issue #213 of Linux (Pro) Magazine in early 2018, shortly after the revelations that

--- a/Elvie_054/README.md
+++ b/Elvie_054/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #054](Elvie_054_en-GB.jpg)
+
 Elvie #054
 ==========
 This strip appeared in issue #214 of Linux (Pro) Magazine in early 2018, shortly after the release of the film "Ocean's 8",

--- a/Elvie_055/README.md
+++ b/Elvie_055/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #055](Elvie_055_en-GB.jpg)
+
 Elvie #055
 ==========
 This strip first appeared in issue #215 of Linux (Pro) Magazine. This one was based on the true story of my

--- a/Elvie_056/README.md
+++ b/Elvie_056/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #056](Elvie_056_en-GB.jpg)
+
 Elvie #056
 ==========
 This strip first appeared in issue #216 of Linux (Pro) Magazine, and is the first of a trilogy of cartoons making up

--- a/Elvie_057/README.md
+++ b/Elvie_057/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #057](Elvie_057_en-GB.jpg)
+
 Elvie #057
 ==========
 This strip first appeared in issue #217 of Linux (Pro) Magazine, and is the second of a trilogy of cartoons making up

--- a/Elvie_058/README.md
+++ b/Elvie_058/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #058](Elvie_058_en-GB.jpg)
+
 Elvie #058
 ==========
 This strip first appeared in issue #218 of Linux (Pro) Magazine, and is the final part of a trilogy of cartoons making up

--- a/Elvie_059/README.md
+++ b/Elvie_059/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #059](Elvie_059_en-GB.jpg)
+
 Elvie #059
 ==========
 This strip first appeared in issue #219 of Linux (Pro) Magazine, shortly after a Code of Conduct was introduced for

--- a/Elvie_060/README.md
+++ b/Elvie_060/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #060](Elvie_060_en-GB.jpg)
+
 Elvie #060
 ==========
 This strip first appeared in issue #220 of Linux (Pro) Magazine, and was the 60th Elvie strip to appear in print. To celebrate

--- a/Elvie_061/README.md
+++ b/Elvie_061/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #061](Elvie_061_en-GB.jpg)
+
 Elvie #061
 ==========
 This strip first appeared in issue #221 of Linux (Pro) Magazine, shortly after Microsoft announced that Edge, their web

--- a/Elvie_062/README.md
+++ b/Elvie_062/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #062](Elvie_062_en-GB.jpg)
+
 Elvie #062
 ==========
 This strip first appeared in issue #222 of Linux (Pro) Magazine.

--- a/Elvie_063/README.md
+++ b/Elvie_063/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #063](Elvie_063_en-GB.jpg)
+
 Elvie #063
 ==========
 This strip first appeared in issue #223 of Linux (Pro) Magazine.

--- a/Elvie_064/README.md
+++ b/Elvie_064/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #064](Elvie_064_en-GB.jpg)
+
 Elvie #064
 ==========
 This strip first appeared in issue #224 of Linux (Pro) Magazine.

--- a/Elvie_065/README.md
+++ b/Elvie_065/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #065](Elvie_065_en-GB.jpg)
+
 Elvie #065
 ==========
 This strip first appeared in issue #225 of Linux (Pro) Magazine.

--- a/Elvie_066/README.md
+++ b/Elvie_066/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #066](Elvie_066_en-GB.jpg)
+
 Elvie #066
 ==========
 This strip first appeared in issue #226 of Linux (Pro) Magazine.

--- a/Elvie_067/README.md
+++ b/Elvie_067/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #067](Elvie_067_en-GB.jpg)
+
 Elvie #067
 ==========
 This strip first appeared in issue #227 of Linux (Pro) Magazine.

--- a/Elvie_068/README.md
+++ b/Elvie_068/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #068](Elvie_068_en-GB.jpg)
+
 Elvie #068
 ==========
 This strip first appeared in issue #228 of Linux (Pro) Magazine, and is inspired by the concerns of every artist or

--- a/Elvie_069/README.md
+++ b/Elvie_069/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #069](Elvie_069_en-GB.jpg)
+
 Elvie #069
 ==========
 This strip first appeared in issue #229 of Linux (Pro) Magazine, and is the second in a trilogy of strips following

--- a/Elvie_070/README.md
+++ b/Elvie_070/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #070](Elvie_070_en-GB.jpg)
+
 Elvie #070
 ==========
 This strip first appeared in issue #230 of Linux (Pro) Magazine, and is the last in a trilogy of strips following

--- a/Elvie_071/README.md
+++ b/Elvie_071/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #071](Elvie_071_en-GB.jpg)
+
 Elvie #071
 ==========
 This strip first appeared in issue #231 of Linux (Pro) Magazine.

--- a/Elvie_072/README.md
+++ b/Elvie_072/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #072](Elvie_072_en-GB.jpg)
+
 Elvie #072
 ==========
 This strip first appeared in issue #232 of Linux (Pro) Magazine.

--- a/Elvie_073/README.md
+++ b/Elvie_073/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #073](Elvie_073_en-GB.jpg)
+
 Elvie #073
 ==========
 This strip first appeared in issue #233 of Linux (Pro) Magazine, and is the first part of a trilogy of strips.

--- a/Elvie_074/README.md
+++ b/Elvie_074/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #074](Elvie_074_en-GB.jpg)
+
 Elvie #074
 ==========
 This strip first appeared in issue #234 of Linux (Pro) Magazine, and is the second part of a trilogy of strips.

--- a/Elvie_075/README.md
+++ b/Elvie_075/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #075](Elvie_075_en-GB.jpg)
+
 Elvie #075
 ==========
 This strip first appeared in issue #235 of Linux (Pro) Magazine, and is the last part of a trilogy of strips.

--- a/Elvie_076/README.md
+++ b/Elvie_076/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #076](Elvie_076_en-GB.jpg)
+
 Elvie #076
 ==========
 This strip first appeared in issue #236 of Linux (Pro) Magazine.

--- a/Elvie_077/README.md
+++ b/Elvie_077/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #077](Elvie_077_en-GB.jpg)
+
 Elvie #077
 ==========
 This strip first appeared in issue #237 of Linux (Pro) Magazine. It was created in mid-2020, at a time when the news was filled with talk of governments around the world creating apps that would use Bluetooth to track your exposure, in terms of proximity and duration, to people who  subsequently tested positive for covid-19. These were generally referred to as "contact tracing" apps.

--- a/Elvie_078/README.md
+++ b/Elvie_078/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #078](Elvie_078_en-GB.jpg)
+
 Elvie #078
 ==========
 This strip first appeared in issue #238 of Linux (Pro) Magazine. It's the first of a pair of strips that are slightly related in their use of tennis as a subject matter. The second strip was written first, with this one subsequently created as a "lead-in".

--- a/Elvie_079/README.md
+++ b/Elvie_079/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #079](Elvie_079_en-GB.jpg)
+
 Elvie #079
 ==========
 This strip first appeared in issue #239 of Linux (Pro) Magazine. It's the second of a pair of strips that are slightly related in their use of tennis as a subject matter.

--- a/Elvie_080/README.md
+++ b/Elvie_080/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #080](Elvie_080_en-GB.jpg)
+
 Elvie #080
 ==========
 This strip first appeared in issue #240 of Linux (Pro) Magazine. It was created at a time when the rise of the Black Lives Matters movement resulted in lots of organisations making relatively small changes in their wording and terminology so that they could appear to be doing the right thing, while not actually making any substantial changes that might have a real and lasting impact on minority groups. This strip is intended to poke fun at such "virtue signalling".

--- a/Elvie_081/README.md
+++ b/Elvie_081/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #081](Elvie_081_en-GB.jpg)
+
 Elvie #081
 ==========
 This strip first appeared in issue #241 of Linux (Pro) Magazine during the coronavirus pandemic of 2020. At that time some sections of the population objected to being required to wear face masks in public indoor environments because it allegedly "encroaches on their civil liberties". It amused us to note that a lot of those psuedo-libertarians are exactly the sort of people who previously would have preferred to wear a mask in public in order to hide their face from CCTV cameras.

--- a/Elvie_082/README.md
+++ b/Elvie_082/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #082](Elvie_082_en-GB.jpg)
+
 Elvie #082
 ==========
 This strip first appeared in issue #242 of Linux (Pro) Magazine, and was paired with the following strip because they both have a home renovation or DIY theme to them.

--- a/Elvie_083/README.md
+++ b/Elvie_083/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #083](Elvie_083_en-GB.jpg)
+
 Elvie #083
 ==========
 This strip first appeared in issue #243 of Linux (Pro) Magazine, and was paired with the previous strip because they both have a home renovation or DIY theme to them.

--- a/Elvie_084/README.md
+++ b/Elvie_084/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #084](Elvie_084_en-GB.jpg)
+
 Elvie #084
 ==========
 This strip first appeared in issue #244 of Linux (Pro) Magazine. It was inspired by the kids in the Code Club that I run. They're aged between 7 and 11, and universally believe that the '#' character is called 'a hashtag'. No amount of explanation or historical insight seems able to shift them from this viewpoint. I therefore predict that eventually the de facto name for this character will become 'hashtag', and all other names will be considered archaic.

--- a/Elvie_085/README.md
+++ b/Elvie_085/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #085](Elvie_085_en-GB.jpg)
+
 Elvie #085
 ==========
 This strip first appeared in issue #245 of Linux (Pro) Magazine and was created in January 2021, during the second coronavirus lockdown in the UK.

--- a/Elvie_086/README.md
+++ b/Elvie_086/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #086](Elvie_086_en-GB.jpg)
+
 Elvie #086
 ==========
 This strip first appeared in issue #246 of Linux (Pro) Magazine and was created in January 2021, shortly after the release of the Raspberry Pi Pico.

--- a/Elvie_087/README.md
+++ b/Elvie_087/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #087](Elvie_087_en-GB.jpg)
+
 Elvie #087
 ==========
 This strip first appeared in issue #247 of Linux (Pro) Magazine and was created early in 2021, shortly after the release of Apple's first M1 CPU.

--- a/Elvie_088/README.md
+++ b/Elvie_088/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #088](Elvie_088_en-GB.jpg)
+
 Elvie #088
 ==========
 This strip first appeared in issue #248 of Linux (Pro) Magazine and was created in 2021, shortly after NASA's Perseverance rover and Ingenuity drone began operating on Mars.

--- a/Elvie_089/README.md
+++ b/Elvie_089/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #089](Elvie_089_en-GB.jpg)
+
 Elvie #089
 ==========
 This strip first appeared in issue #249 of Linux (Pro) Magazine and was created in 2021, shortly after NASA's Perseverance rover and Ingenuity drone began operating on Mars. At that time NASA released audio recordings that were captured by the rover.

--- a/Elvie_090/README.md
+++ b/Elvie_090/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #090](Elvie_090_en-GB.jpg)
+
 Elvie #090
 ==========
 This strip first appeared in issue #250 of Linux (Pro) Magazine.

--- a/Elvie_091/README.md
+++ b/Elvie_091/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #091](Elvie_091_en-GB.jpg)
+
 Elvie #091
 ==========
 This strip first appeared in issue #251 of Linux (Pro) Magazine. It's the first of a pair of strips that summarise

--- a/Elvie_092/README.md
+++ b/Elvie_092/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #092](Elvie_092_en-GB.jpg)
+
 Elvie #092
 ==========
 This strip first appeared in issue #252 of Linux (Pro) Magazine. It's the second of a pair of strips that summarise

--- a/Elvie_093/README.md
+++ b/Elvie_093/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #093](Elvie_093_en-GB.jpg)
+
 Elvie #093
 ==========
 This strip first appeared in issue #253 of Linux (Pro) Magazine. Usually Mark writes these strips, Vince draws the images, then

--- a/Elvie_094/README.md
+++ b/Elvie_094/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #094](Elvie_094_en-GB.jpg)
+
 Elvie #094
 ==========
 This strip first appeared in issue #254 of Linux (Pro) Magazine, in October 2021 when the price of Bitcoin was approaching

--- a/Elvie_095/README.md
+++ b/Elvie_095/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #095](Elvie_095_en-GB.jpg)
+
 Elvie #095
 ==========
 This strip first appeared in issue #255 of Linux (Pro) Magazine, in November 2021 when the price of Bitcoin was approaching

--- a/Elvie_096/README.md
+++ b/Elvie_096/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #096](Elvie_096_en-GB.jpg)
+
 Elvie #096
 ==========
 This strip first appeared in issue #256 of Linux (Pro) Magazine. It refers to the fact that Apple's Safari is effectively

--- a/Elvie_097/README.md
+++ b/Elvie_097/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #097](Elvie_097_en-GB.jpg)
+
 Elvie #097
 ==========
 This strip first appeared in issue #257 of Linux (Pro) Magazine.

--- a/Elvie_098/README.md
+++ b/Elvie_098/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #098](Elvie_098_en-GB.jpg)
+
 Elvie #098
 ==========
 This strip first appeared in issue #258 of Linux (Pro) Magazine.

--- a/Elvie_099/README.md
+++ b/Elvie_099/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #099](Elvie_099_en-GB.jpg)
+
 Elvie #099
 ==========
 This strip first appeared in issue #259 of Linux (Pro) Magazine. This was shortly after Russia's invasion of Ukraine, so we chose to colour the logo, and Elvie's hair and T-shirt as a small gesture of solidarity with the Ukrainian people.

--- a/Elvie_100/README.md
+++ b/Elvie_100/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #100](Elvie_100_en-GB.jpg)
+
 Elvie #100
 ==========
 This strip first appeared in issue #260 of Linux (Pro) Magazine. The Elvie series was originally written for Linux Voice


### PR DESCRIPTION
In the `README.md` for each strip, prepend a link to the final JPEG image so that the corresponding
cartoon is visible when browsing the repo via the GitHub web UI.